### PR TITLE
fix: add sbt/setup-sbt@v1 for ubuntu-latest 24.04 compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,7 @@ jobs:
             ~/.sbt
             ~/.cache/coursier
           key: global-sbt-cache
+      - uses: sbt/setup-sbt@v1
       - name: Setup GPG
         run: |
           echo "$PRIVATE_GPG_KEY" > private.key


### PR DESCRIPTION
## Problem

\`ubuntu-latest\` now maps to Ubuntu 24.04, which no longer ships \`sbt\` pre-installed. The CI workflow calls \`sbt test\` (and \`sbt … +publishSigned\`) without ever installing sbt, causing the job to fail with \`command not found: sbt\`.

## Fix

Add \`- uses: sbt/setup-sbt@v1\` immediately after the \`actions/cache@v3\` step so that sbt is installed before any \`sbt\` commands are run.