### PR TITLE
chore: bump jnats client from 2.17.4 to 2.26.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,5 +66,5 @@ libraryDependencies := Seq(
   "org.scalatest" %% "scalatest" % "3.0.8" % Test,
   "org.scalamock" %% "scalamock" % "4.4.0" % Test,
   "org.testcontainers" % "testcontainers" % "1.17.5" % Test,
-  "io.nats" % "jnats" % "2.17.4"
+  "io.nats" % "jnats" % "2.26.2"
 )


### PR DESCRIPTION
## Summary
- Bumps `io.nats:jnats` from `2.17.4` to `2.26.2` (latest on Maven Central).
- Our pin was 8 minor versions behind `2.25.3` ("Server 2.14 Support" — flow control, reset-consumer), with no client-side support at all for nats-server v2.12+ features.
- Prerequisite for an upcoming `nats-server` upgrade past the currently-running `v2.11.4` in prod — every Scala service picks this up transitively through `commons-backend`.

## Test plan
- [x] `sbt compile` — clean
- [x] `sbt Test/compile` — clean (pre-existing unrelated deprecation warnings only, not introduced by this change)
- [x] `sbt test` against a real NATS server via testcontainers — **9/9 tests pass**, including the JetStream-specific suite (`JetStreamSourceStageTest`)