### PR TITLE
fix: point publishTo at Sonatype Central Publisher Portal

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,11 +15,12 @@ publishMavenStyle := true
 publishArtifact in Test := false
 
 publishTo := {
-  val nexus = "https://oss.sonatype.org/"
   if (isSnapshot.value)
-    Some("snapshots" at nexus + "content/repositories/snapshots")
+    Some("snapshots" at "https://central.sonatype.com/repository/maven-snapshots/")
   else
-    Some("releases" at nexus + "service/local/staging/deploy/maven2")
+    Some(
+      "releases" at "https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2"
+    )
 }
 
 credentials += Credentials(


### PR DESCRIPTION
## Summary
- `oss.sonatype.org` was decommissioned 2025-06-30 (OSSRH end-of-life) — `publishTo` was still pointed at it, so `sbt publishSigned` in the release job (triggered on push to `master`) would fail outright the next time we cut a release.
- Points releases at the OSSRH Staging API compatibility bridge (`ossrh-staging-api.central.sonatype.com`) and snapshots at the new native Central Portal snapshot repo (`central.sonatype.com/repository/maven-snapshots/`).
- Companion doc fix: `technical-documentation` PR #4 updates the internal release runbook to match.

## Follow-up needed (outside this repo, can't do from here)
- The `OSS_NEXUS_CREDENTIALS` GitHub secret currently holds old OSSRH username/password-style credentials. It needs to be regenerated as a **Central Portal User Token** from https://central.sonatype.com/publishing and the secret content updated to match — otherwise `publishSigned` will fail auth even with the corrected URL.

## Test plan
- [x] `sbt compile` succeeds with the new `publishTo` config (can't test an actual `publishSigned` run without valid Central Portal credentials, which is the follow-up above)