### PR TITLE
fix: remove dead pgp.credentials file reference blocking sonaUpload

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,10 +36,6 @@ credentials += Credentials(
   sys.env.getOrElse("SONATYPE_PASSWORD", "")
 )
 
-credentials in GlobalScope += Credentials(
-  file(s"${baseDirectory.value.getAbsolutePath}/pgp.credentials")
-)
-
 pomIncludeRepository := { _ =>
   false
 }


### PR DESCRIPTION
## Summary
Follow-up to #12. That PR's `sonaUpload` migration surfaced a real, pre-existing bug: `credentials in GlobalScope += Credentials(file(".../pgp.credentials"))` never pointed at a file that actually exists — the real PGP passphrase has always come from `pgpPassphrase := sys.env.get("PGP_PASS")` instead. Under the old Ivy-based `publishSigned` flow this dead entry only ever produced a harmless `[warn] Credentials file ... does not exist` line. sbt's native `sonaUpload` is stricter: it eagerly resolves every registered `Credentials` entry and throws a hard `RuntimeException` on the first unresolvable one, which made every release build fail immediately:

```
java.lang.RuntimeException: Credentials file .../pgp.credentials does not exist
  at sbt.internal.librarymanagement.Publishing$.sonatypeReleaseAction
```

Fix: delete the dead entry.

## Test plan
- [x] `sbt compile` — clean, and the (harmless but now-gone) warning about the missing file no longer appears at all
- [x] `sbt 'set isSnapshot := false' 'set version := IO.read(new File("VERSION")).mkString.trim' sonaUpload` with dummy `SONATYPE_USERNAME`/`SONATYPE_PASSWORD` — **gets past credential resolution entirely** and makes a real HTTP request to Central's native bundle-upload API, failing only with `401` against the deliberately-fake credentials. Confirms the actual blocker is gone; the remaining failure is exactly the expected "no real token on this machine" case, not a bug.